### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "billingbudgets",
     "name_pretty": "Cloud Billing Budget",
     "product_documentation": "https://cloud.google.com/billing/docs/how-to/budget-api-overview",
-    "client_documentation": "https://googleapis.dev/python/billingbudgets/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/billingbudgets/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559770",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.