### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "billingbudgets",
     "name_pretty": "Cloud Billing Budget",
     "product_documentation": "https://cloud.google.com/billing/docs/how-to/budget-api-overview",
-    "client_documentation": "https://googleapis.dev/python/billingbudgets/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/billingbudgets/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559770",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ plan.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-billing-budgets.svg
    :target: https://pypi.org/project/google-cloud-billing-budgets/
 .. _Cloud Billing Budget API: https://cloud.google.com/billing/docs/how-to/budget-api-overview
-.. _Client Library Documentation: https://googleapis.dev/python/billingbudgets/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/billingbudgets/latest
 .. _Product Documentation:  https://cloud.google.com/billing/docs/how-to/budget-api-overview
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.