### PR TITLE
chore: prepare for the monorepo migration

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -49,13 +49,6 @@ templated_files = gcp.CommonTemplates().py_library(
 )
 s.move(templated_files, excludes=[".coveragerc", ".github/release-please.yml"])
 
-# This replacement will no longer be required once this repo is migrated to google-cloud-python
-s.replace(
-    "setup.py",
-    "https://github.com/googleapis/python-billing-budgets",
-    "https://github.com/googleapis/python-billingbudgets",
-)
-
 python.py_samples(skip_readmes=True)
 
 # run format session for all directories which have a noxfile


### PR DESCRIPTION
Towards https://github.com/googleapis/google-cloud-python/issues/10994

Remove replacement in owlbot.py which will be obsolete in the monorepo as the reason for the customization was due to the discrepancy between the package name `google-cloud-billing-budgets` and the repository name `python-billingbudgets` (no hyphen). In the monorepo, we will have package `google-cloud-billing-budgets` which is predictable.